### PR TITLE
Fix OpenAI client usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.env

--- a/mcp_templates/mcp-docgen-agent/main_v1.py
+++ b/mcp_templates/mcp-docgen-agent/main_v1.py
@@ -46,14 +46,14 @@ async def generate_docs(payload: CodePayload):
             )
 
             try:
-                openai.api_key = api_key
-                completion = openai.ChatCompletion.create(
+                client = openai.OpenAI(api_key=api_key)
+                completion = client.chat.completions.create(
                     model="gpt-4",
                     messages=[{"role": "user", "content": doc_prompt}],
                     temperature=0.2,
                     max_tokens=150,
                 )
-                doc = completion.choices[0].message["content"].strip()
+                doc = completion.choices[0].message.content.strip()
             except Exception as exc:
                 raise HTTPException(status_code=500, detail=str(exc))
         else:


### PR DESCRIPTION
## Summary
- use new `openai.OpenAI` client in `main_v1.py`
- ignore `.env` so secrets aren't committed

## Testing
- `pip install -r mcp_templates/mcp-docgen-agent/requirements.txt`
- `bash scripts/environment_setup.sh`
- `bash check_env.sh`
- `bash setup_and_test.sh`
- start server `python mcp_templates/mcp-docgen-agent/main_v1.py` and call endpoints


------
https://chatgpt.com/codex/tasks/task_e_6846825d5a60832183e901d466403284