### PR TITLE
Add Bacon Blog Inspector MVP

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+GITHUB_ACCOUNT=your_github_account
+GITHUB_REPO_NAME=bacon-ai-codex-mcp-bootstraps
+GITHUB_PAT_KEY=<your_pat_here>
+OPENAI_API_KEY=<your_openai_key_here>
+GEMINI_API_KEY=<your_gemini_key_here>
+BLOG_INSPECTOR_TOKEN=<your_blog_inspector_token>

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 GITHUB_REPO_NAME=<add your repo here>
 GITHUB_ACCOUNT=<Add your GH account name here>
 GITHUB_PAT_KEY=<add your key here>
-OPENAI_API_KEY=<sk-proj-...add your API Key here> 
-OPENAI_API_KEY_CODEX=<sk-proj-...add your API Key here> 
-GEMINI_API_KEY=<add your API Key here> 
+OPENAI_API_KEY=<sk-proj-...add your API Key here>
+OPENAI_API_KEY_CODEX=<sk-proj-...add your API Key here>
+GEMINI_API_KEY=<add your API Key here>
+BLOG_INSPECTOR_TOKEN=<add inspector auth token here>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Before running any scripts, ensure that the following environment variables are 
 2. **GITHUB_ACCOUNT**: Your GitHub username (e.g., `thebacons`).
 3. **GITHUB_PAT_KEY**: Your GitHub Personal Access Token with sufficient permissions to push to the repository.
 4. **OPENAI_API_KEY**: The API key for OpenAI, required to interact with GPT models for generating docstrings.
+5. **BLOG_INSPECTOR_TOKEN**: Authentication token for the Bacon Blog Inspector service.
 
 Codex should look for these values in **Environment Variables** as well as **Secrets**. If any of these variables are missing, you will receive a clear error message.
 

--- a/NextSteps_20250609_074440.md
+++ b/NextSteps_20250609_074440.md
@@ -1,0 +1,15 @@
+# Next Steps for API Key Integration
+
+This project uses environment variables stored in `.env` for all secrets.
+
+## Required Keys
+- `OPENAI_API_KEY` – existing key for GPT-4 interactions.
+- `GEMINI_API_KEY` – key for Gemini API (if used).
+- `BLOG_INSPECTOR_TOKEN` – token for authenticating requests to the Blog Inspector service.
+
+Add any new keys to `.env` and document them here with brief setup instructions.
+
+1. Copy `.env.example` to `.env` and fill in your values.
+2. For new services, append the key name and usage notes here.
+
+Commit this file whenever new integrations are added so changes are tracked.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,20 @@ If needed, revert to your original stable script after initial scaffolding:
 ## 📄 License
 
 MIT License – use freely, fork, modify, go wild 🍳
-EOF
 
+
+
+---
+
+## Bacon Blog Inspector
+
+The `blog_inspector` package provides a simple FastAPI service for analyzing blog posts.
+It requires `BLOG_INSPECTOR_TOKEN` and `OPENAI_API_KEY` in your `.env` file.
+
+Run locally with:
+
+```bash
+uvicorn blog_inspector.main:app --reload --port 8081
 ```
 
-
+Send authenticated POST requests to `/inspect` with your blog content to receive analysis and improvement suggestions.

--- a/blog_inspector/main.py
+++ b/blog_inspector/main.py
@@ -1,0 +1,63 @@
+import os
+from typing import Optional
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import openai
+
+load_dotenv()
+
+app = FastAPI(title="Bacon Blog Inspector")
+
+security = HTTPBearer()
+
+API_TOKEN = os.getenv("BLOG_INSPECTOR_TOKEN")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+class BlogPayload(BaseModel):
+    title: str
+    content: str
+
+
+def authenticate(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    if API_TOKEN is None:
+        raise HTTPException(status_code=500, detail="Server missing BLOG_INSPECTOR_TOKEN")
+    if credentials.credentials != API_TOKEN:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+
+
+@app.post("/inspect")
+async def inspect_blog(payload: BlogPayload, creds: HTTPAuthorizationCredentials = Depends(authenticate)):
+    if not OPENAI_API_KEY:
+        raise HTTPException(status_code=500, detail="Missing OPENAI_API_KEY")
+
+    prompt = f"Summarize the following blog post and list any potential improvements:\n\nTitle: {payload.title}\n\n{payload.content}"
+    try:
+        client = openai.OpenAI(api_key=OPENAI_API_KEY)
+        completion = client.chat.completions.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.2,
+            max_tokens=300,
+        )
+        response = completion.choices[0].message.content.strip()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return {"analysis": response}
+
+
+@app.get("/.well-known/mcp/manifest.json")
+async def manifest():
+    return {
+        "name": "Bacon Blog Inspector",
+        "description": "Analyzes blog posts using OpenAI GPT-4 and returns suggestions.",
+        "endpoints": ["/inspect"],
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8081)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.29.0
 openai>=1.3.5
 python-dotenv==1.0.1
 pydantic>=1.10.0,<3.0.0
+pytest==8.2.0
+pytest-asyncio==0.23.6

--- a/tests/test_blog_inspector.py
+++ b/tests/test_blog_inspector.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from pathlib import Path
+import pytest
+import httpx
+
+os.environ['BLOG_INSPECTOR_TOKEN'] = 'testtoken'
+os.environ['OPENAI_API_KEY'] = 'dummy'
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from blog_inspector.main import app
+
+class DummyChoice:
+    def __init__(self, content):
+        self.message = type('obj', (), {'content': content})
+
+class DummyCompletion:
+    def __init__(self, text):
+        self.choices = [DummyChoice(text)]
+
+@pytest.mark.asyncio
+async def test_inspect_blog(monkeypatch):
+    def fake_create(**kwargs):
+        return DummyCompletion('Analysis result')
+
+    monkeypatch.setattr('openai.OpenAI', lambda api_key=None: type('C', (), {
+        'chat': type('CC', (), {
+            'completions': type('CC2', (), {
+                'create': staticmethod(fake_create)
+            })()
+        })()
+    }))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post('/inspect', json={'title': 't', 'content': 'c'}, headers={'Authorization': 'Bearer testtoken'})
+    assert resp.status_code == 200
+    assert resp.json()['analysis'] == 'Analysis result'


### PR DESCRIPTION
## Summary
- add Bacon Blog Inspector FastAPI service
- document new BLOG_INSPECTOR_TOKEN in AGENTS and README
- include placeholder environment keys and next steps file
- add pytest-based test for the blog inspector
- update dependencies

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846905a4f4c8321808833502abfe5f1